### PR TITLE
Append enabled_option

### DIFF
--- a/lib/vagrant-sshfs/actions.rb
+++ b/lib/vagrant-sshfs/actions.rb
@@ -100,12 +100,15 @@ module Vagrant
 
       class Up
         def initialize(app, env)
-          @app     = app
+          @app = app
+          @env = env
           @machine = env[:machine]
         end
 
         def call(env)
-          Builder.new(env).mount!
+          if @env[:machine].config.sshfs.enabled then
+              Builder.new(env).mount!
+          end
         end
       end
     end

--- a/lib/vagrant-sshfs/config.rb
+++ b/lib/vagrant-sshfs/config.rb
@@ -3,10 +3,12 @@ module Vagrant
     class Config < Vagrant.plugin(2, :config)
       attr_accessor :paths
       attr_accessor :username
+      attr_accessor :enabled
 
       def initialize
         @paths = {}
         @username = nil
+        @enabled = true
       end
 
       def merge(other)


### PR DESCRIPTION
With this option, I can disable sshfs auto start.

Next, I will append a new command : 

```
vagrant sshfs
```

Why this need ? I my project I need to mount some folder. This folder didn't exists before Ansible provisioning.

My workflow : 
- vagrant up (provisioning is executed)
- vagrant sshfs (now I can mount folder because provisioning have create its)
