### PR TITLE
Fix remote host has disconnected problem

### DIFF
--- a/lib/vagrant-sshfs/builders/host.rb
+++ b/lib/vagrant-sshfs/builders/host.rb
@@ -15,7 +15,7 @@ module Vagrant
         end
 
         def mount(src, target)
-          `#{sshfs_bin} -p #{port} #{username}@#{host}:#{check_src!(src)} #{check_target!(target)} -o IdentityFile=#{private_key}`
+          `#{sshfs_bin} -p #{port} #{username}@#{host}:#{check_src!(src)} #{check_target!(target)} -o IdentityFile=#{private_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null `
         end
 
         def ssh_info


### PR DESCRIPTION
After installing vagrant-sshfs and configuring sshfs paths in a Vagrantfile, if you run:

```
$ vagrant up
$ vagrant destroy
$ vagrant up
```

The sshfs mounts no longer work due to the the known_hosts entry for the original Vagrant box that was destroyed.

By adding a few options to the sshfs command to pass to ssh, we can disregard the known_hosts file.

This also eliminates the prompt for accepting the host identity when running `vagrant up` for the first time.
