### PR TITLE
Anableing alternative options.

### DIFF
--- a/lib/vagrant-sshfs/builders/guest.rb
+++ b/lib/vagrant-sshfs/builders/guest.rb
@@ -12,15 +12,15 @@ module Vagrant
           end
         end
 
-        def mount(src, target)
+        def mount(src, target, otheroptions)
           source = File.expand_path(src)
 
           status = machine.communicate.execute(
-            "echo \"#{password}\" | sshfs -o allow_other -o password_stdin #{username}@#{host}:#{source} #{target}",
+            "echo \"#{password}\" | sshfs -o allow_other -o password_stdin -o #{otheroptions} #{username}@#{host}:#{source} #{target}",
             :sudo => true, :error_check => false)
 
           if status != 0
-            error('not_mounted', src: source, target: target)
+            error('not_mounted', src: source, target: target, opt: otheroptions)
           end
         end
 


### PR DESCRIPTION
I would like to use some options like.
Eg:

sshfs -o uid=80,gid=80,allow_other,rw,use_cache=/tmp,retries=60,default_acl=public-read,connect_timeout=30,readwrite_timeout=120,max_stat_cache_size=100000,nodnscache,del_cache,multireq_max=30,parallel_count=20" src target