### PR TITLE
Wording clarification during folder creation

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,8 +9,8 @@ en:
           created_src: "Created src `%{src}`"
           created_target: "Created target `%{target}`"
         ask:
-          create_src: "Source folder `%{src}` does not exist, create?"
-          create_target: "Target folder `%{target}` does not exist, create?"
+          create_src: "Source folder `%{src}` does not exist, create? (y/n)"
+          create_target: "Target folder `%{target}` does not exist, create? (y/n)"
           pass: "Password for `%{user}`:"
         error:
           base: "vagrant-sshfs failed and couldn't proceed"


### PR DESCRIPTION
Update for new folder creation to make it clear we are expecting a single character 'y' for a positive answer.