### PR TITLE
Name volumes in OSX as the final directory in the source path

### DIFF
--- a/lib/vagrant-sshfs/builders/host.rb
+++ b/lib/vagrant-sshfs/builders/host.rb
@@ -16,7 +16,12 @@ module Vagrant
         end
 
         def mount(src, target)
-          `#{sshfs_bin} -p #{port} #{username}@#{host}:#{check_src!(src)} #{check_target!(target)} -o IdentityFile=#{private_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null `
+          if machine.config.sshfs.name_volumes and (/darwin/ =~ RUBY_PLATFORM) != nil
+            last_dir_name = src.split(File::SEPARATOR)[-1]
+            extra_options = "-o volname=#{last_dir_name}"
+          end
+
+          `#{sshfs_bin} -p #{port} #{username}@#{host}:#{check_src!(src)} #{check_target!(target)} -o IdentityFile=#{private_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null #{extra_options} `
         end
 
         def ssh_info

--- a/lib/vagrant-sshfs/config.rb
+++ b/lib/vagrant-sshfs/config.rb
@@ -8,6 +8,7 @@ module Vagrant
       attr_accessor :sudo
       attr_accessor :mount_on_guest
       attr_accessor :host_addr
+      attr_accessor :name_volumes
 
       def initialize
         @paths = {}
@@ -15,6 +16,7 @@ module Vagrant
         @enabled = true
         @prompt_create_folders = false
         @sudo = true
+        @name_volumes = true
       end
 
       def merge(other)

--- a/lib/vagrant-sshfs/version.rb
+++ b/lib/vagrant-sshfs/version.rb
@@ -1,5 +1,5 @@
 module Vagrant
   module SshFS
-    VERSION = "0.0.7"
+    VERSION = "0.0.9"
   end
 end


### PR DESCRIPTION
In OSX the sshfs library actually mounts a new volume and gives is a weird name like "OSX Fuse Volume 0" - this gives it a human readable name.

This uses the `volname` option of the SSHFS library we have to use in OSX - https://osxfuse.github.io/. 

Detects if the vagrant is running on OSX and adds the extra option then only as it doesn't exist on*nix sshfs. Rather than specifying a name manually for each path we just pull of the last directory name of the source path.

i.e. `for /home/vagrant/src` we pull off `src`
